### PR TITLE
feat(BaksButton): refactor and add submit prop

### DIFF
--- a/packages/web-components/css.d.ts
+++ b/packages/web-components/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/packages/web-components/lib/components/baks-button/BaksButton.stories.ts
+++ b/packages/web-components/lib/components/baks-button/BaksButton.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { register } from '../../';
-
+import { expect, userEvent, within } from '@storybook/test';
 import { html } from 'lit';
 import { variantsOptions } from 'baks-components-styles';
 
@@ -17,33 +16,72 @@ const meta: Meta = {
     size: {
       options: ['normal', 'block'],
       control: { type: 'select' }
+    },
+    slot: {
+      control: { type: 'text' }
+    },
+    role: {
+      control: { type: 'text' }
     }
+  },
+  args: {
+    variant: 'primary',
+    size: 'normal',
+    slot: 'Click me',
+    role: 'button'
   }
 };
 
 export default meta;
 type Story = StoryObj;
 
-register(['BaksButton']);
-
 export const Normal: Story = {
   args: {
-    variant: 'primary',
     disabled: false,
-    size: 'normal'
   },
-  render: ({ variant, disabled, size }) => {
-    return html`<baks-button variant="${variant} size="${size}">Hello</baks-button>`;
+  render({ variant, disabled, size, slot, role }) {
+    return html`
+      <baks-button 
+        ?disabled="${disabled}"
+        variant="${variant}"
+        size=${size}
+        role="button"
+        >
+        ${slot}
+        </baks-button`;
+  },
+  play: async ({ args, container, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    let isClicked = false;
+    button.addEventListener('click', () => (isClicked = true));
+    await userEvent.click(button);
+    expect(isClicked).toBe(true);
   }
 };
 
 export const Disabled: Story = {
   args: {
-    variant: 'primary',
     disabled: true,
-    size: 'normal'
   },
-  render: ({ variant, disabled, size }) => {
-    return html`<baks-button variant="${variant} size="${size}" disabled='true'>Hello</baks-button>`;
+  render({ variant, disabled, size, slot, role }) {
+    return html`
+      <baks-button 
+        ?disabled="${disabled}"
+        variant="${variant}"
+        size=${size}
+        role="button"
+        >
+        ${slot}
+        </baks-button`;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+
+    let isClicked = false;
+    button.addEventListener('click', () => (isClicked = true));
+    expect(isClicked).not.toBe(true);
+    expect(button).toBeDisabled();
   }
 };

--- a/packages/web-components/lib/components/baks-button/BaksButton.ts
+++ b/packages/web-components/lib/components/baks-button/BaksButton.ts
@@ -1,0 +1,60 @@
+import { html, LitElement, unsafeCSS } from 'lit';
+import style from 'baks-components-styles/src/css/baks-button.css?inline';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('baks-button')
+export class BaksButton extends LitElement {
+  static styles = unsafeCSS(style);
+  static formAssociated = true;
+  #internals;
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+    this.#internals.ariaRole = 'button';
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    /**
+     * This is a workaround to mimic native sumit button behavior,
+     * just until web components support this out of the box
+     * @see https://github.com/WICG/webcomponents/issues/814
+     */
+    if (this.#internals.form !== null && this.type === 'submit') {
+      this.addEventListener('click', () => {
+        this.#internals.form.requestSubmit();
+      });
+    }
+  }
+
+  @property({ type: String })
+  variant = 'primary';
+
+  get _variantClassName() {
+    return `bk-${this.variant}`;
+  }
+
+  @property({ type: String })
+  size = 'normal';
+
+  @property({ type: String })
+  type = 'button';
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  render() {
+    const { disabled, _variantClassName, size, type } = this;
+
+    return html`<button
+      ?disabled="${disabled}"
+      type="${type}"
+      class="${disabled ? 'disabled' : ''} ${size === 'block'
+        ? 'w-full'
+        : ''} ${_variantClassName} bk-button hover shadow-sm shadow-black px-6 py-1.5 cursor-pointer rounded min-w-24"
+    >
+      <slot></slot>
+    </button>`;
+  }
+}

--- a/packages/web-components/lib/index.ts
+++ b/packages/web-components/lib/index.ts
@@ -1,5 +1,5 @@
 import { defineCustomElement } from 'vue';
-import BaksButton from 'baks-components-vue/lib/components/baks-button/BaksButton.vue';
+import { BaksButton } from './components/baks-button/BaksButton'
 import './app.css';
 import { registerComponent } from './utilities/registerComponent';
 import BaksCardCe from './components/baks-card/BaksCard.ce.vue';
@@ -11,7 +11,6 @@ export type { ThemeVariant as ThemeVariants } from 'baks-components-styles';
 
 
 const BaksCard = defineCustomElement(BaksCardCe);
-const BaksButtonCe = defineCustomElement(BaksButton);
 const BaksAccordionCE = defineCustomElement(BaksAccordion);
 const BaksTabCE = defineCustomElement(BaksTab);
 const BaksTabListW = defineCustomElement(BaksTabList);
@@ -19,7 +18,7 @@ const BaksTabPanelCe = defineCustomElement(BaksTabPanel);
 
 export {
   BaksCard,
-  BaksButtonCe as BaksButton,
+  BaksButton,
   BaksAccordion,
   BaksTabCE as BaksTab,
   BaksTabListW as BaksTabList,
@@ -36,7 +35,6 @@ export type Components =
 
 export function register(specificComponents: Components[] = []) {
   if (specificComponents.length === 0) {
-    registerComponent('baks-button', BaksButtonCe);
     registerComponent('baks-card', BaksCard);
     registerComponent('baks-accordion', BaksAccordionCE);
     registerComponent('baks-tab', BaksTabCE);
@@ -45,9 +43,6 @@ export function register(specificComponents: Components[] = []) {
   } else {
     specificComponents.forEach((component) => {
       switch (component) {
-        case 'BaksButton':
-          registerComponent('baks-button', BaksButtonCe);
-          break;
         case 'BaksCard':
           registerComponent('baks-card', BaksCard);
           break;

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -34,6 +34,7 @@
     "autoprefixer": "^10.4.19",
     "baks-components-styles": "^0.2.0",
     "glob": "^10.3.12",
+    "lit": "^3.1.4",
     "tailwindcss": "^3.4.3",
     "uuid": "^9.0.1",
     "vite-plugin-dts": "^3.9.1",
@@ -42,13 +43,13 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.3",
     "@rushstack/eslint-patch": "^1.8.0",
-    "@storybook/addon-essentials": "^8.0.9",
-    "@storybook/addon-interactions": "^8.0.9",
-    "@storybook/addon-links": "^8.0.9",
-    "@storybook/blocks": "^8.0.9",
-    "@storybook/test": "^8.0.9",
-    "@storybook/web-components": "^8.0.9",
-    "@storybook/web-components-vite": "^8.0.9",
+    "@storybook/addon-essentials": "^8.2.1",
+    "@storybook/addon-interactions": "^8.2.1",
+    "@storybook/addon-links": "^8.2.1",
+    "@storybook/blocks": "^8.2.1",
+    "@storybook/test": "^8.2.1",
+    "@storybook/web-components": "^8.2.1",
+    "@storybook/web-components-vite": "^8.2.1",
     "@tsconfig/node20": "^20.1.4",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.12.5",
@@ -64,11 +65,10 @@
     "npm-run-all2": "^6.1.2",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
-    "storybook": "^8.0.9",
+    "storybook": "^8.2.1",
     "typescript": "~5.4.0",
     "vite": "^5.2.8",
     "vitest": "^1.4.0",
     "vue-tsc": "^2.0.11"
-  },
-  "packageManager": "yarn@1.22.19"
+  }
 }

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -1,3 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "include": ["lib/**/*", "src/**/*", "env.d.ts", "css.d.ts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "moduleResolution": "Node",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+  }
 }


### PR DESCRIPTION
This PR introduces lit to the tech stack with a refactoring of BaksButton.
This is because vue doesn't support form associated custom elements out of the box.