### PR TITLE
refactor(BaksTabListW): more robust logic

### DIFF
--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { register } from '../../';
+
+import { html } from 'lit';
+import { variantsOptions } from 'baks-components-styles';
+import { expect, within } from '@storybook/test';
+
+const meta: Meta = {
+  component: 'baks-button',
+  argTypes: {
+    direction: {
+      options: ['horizontal', 'vertical'],
+      control: { type: 'select' }
+    },
+    variant: {
+      options: variantsOptions,
+      control: { type: 'select' }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj;
+
+register(['BaksTabListW', 'BaksTab', 'BaksTabPanel']);
+
+export const Normal: Story = {
+  args: {
+    direction: 'horizontal',
+    variant: 'primary'
+  },
+  render: ({ direction, variant }) => {
+    return html`     <baks-tab-list-w direction="${direction}">
+      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" selected>
+        Test 1
+      </baks-tab>
+      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel2" role="tab">
+        Test 2
+      </baks-tab>
+      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel3" role="tab">
+        Test 3
+      </baks-tab>
+      <div slot="panel">
+        <baks-tab-panel id="sidebar-log-tabpanel" role="tabpanel">Hello</baks-tab-panel>
+        <baks-tab-panel id="sidebar-log-tabpanel2" role="tabpanel">2</baks-tab-panel>
+        <baks-tab-panel id="sidebar-log-tabpanel3" role="tabpanel">3</baks-tab-panel>
+      </div>
+    </baks-tab-list-w>`;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = canvas.getAllByRole('tab');
+    const button = buttons.find((button) => button.getAttribute("selected") === null);
+    const clickedButton = buttons.find((button) => button.getAttribute("selected") !== null);
+    button.click();
+
+    expect(button.getAttribute("selected")).not.toBe(null);
+    expect(clickedButton.getAttribute("selected")).toBe(null);
+
+    const panelShouldBeVisibleId = button.getAttribute("controls");
+    const panels = canvas.getAllByRole("tabpanel");
+    const panel = panels.find((panel) => panel.getAttribute("id") === panelShouldBeVisibleId);
+
+    expect(panel.getAttribute("is-visible")).not.toBe(null);
+  }
+};

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsListW.ce.vue
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsListW.ce.vue
@@ -2,9 +2,7 @@
   <div
     class="bk-tabs-list-w"
     ref="tabsWrapper"
-    part="bk-tabs-list-w"
-    :class="direction"
-  >
+    part="bk-tabs-list-w" :class="direction">
     <div class="bk-tabs border-none" :class="direction" part="bk-tabs">
       <slot></slot>
     </div>
@@ -17,11 +15,6 @@
 <script setup lang="ts">
 import { getCurrentInstance, onMounted, ref, watch } from 'vue';
 
-interface HTMLElementVue extends HTMLElement {
-  _props: {
-    [key: string]: string;
-  };
-}
 interface Props {
   direction?: 'horizontal' | 'vertical';
 }
@@ -30,11 +23,11 @@ const props = withDefaults(defineProps<Props>(), {
   direction: 'horizontal'
 });
 
-const tabsWrapper = ref<HTMLElementVue | null>();
+const tabsWrapper = ref<HTMLElement | null>();
 
-const tabs = ref<HTMLElementVue[]>([]);
+const tabs = ref<HTMLElement[]>([]);
 
-const tabsPanels = ref<HTMLElementVue[]>([]);
+const tabsPanels = ref<HTMLElement[]>([]);
 const visibleTabPanel = ref<string>();
 const setVisibleTabPanel = (id: string) => {
   visibleTabPanel.value = id;
@@ -45,15 +38,6 @@ const setVisibleTabPanel = (id: string) => {
       panel.removeAttribute('is-visible');
     }
   });
-};
-
-const togglePanel = (id: string, shouldHide: boolean) => {
-  const element = document.querySelectorAll(`#${id}`)[0];
-  if (shouldHide) {
-    element.removeAttribute('is-visible');
-  } else {
-    element.setAttribute('is-visible', '');
-  }
 };
 
 watch(
@@ -69,8 +53,7 @@ onMounted(() => {
   const instance = getCurrentInstance();
   const root = instance?.root.vnode.el;
   const host = root?.parentNode.host as HTMLElement;
-
-  tabs.value = <HTMLElementVue[]>(
+  tabs.value = <HTMLElement[]>(
     [...host?.children].filter((element) => element.tagName === 'BAKS-TAB')
   );
 
@@ -83,25 +66,26 @@ onMounted(() => {
       }
     }
 
-    const element = <HTMLElementVue>document.querySelectorAll(`#${tab._props.controls}`)[0];
+    const tabPanelIdentifier = tab.attributes.getNamedItem("controls").value;
+    const element = <HTMLElement>document.querySelectorAll(`#${tabPanelIdentifier}`)[0];
+
     if (element !== undefined) {
       tabsPanels.value.push(element);
     }
 
     if (tab.hasAttribute('selected')) {
-      setVisibleTabPanel(tab._props.controls);
+      setVisibleTabPanel(tabPanelIdentifier);
     }
 
-    tab.addEventListener('bk:click', (e) => {
-      tabs.value.forEach((tab) => {
-        if (tab !== e.target) {
-          tab.removeAttribute('selected');
-          togglePanel(tab._props.controls, true);
+    tab.addEventListener('click', (e) => {
+      tabs.value.forEach(element => {
+        if(element !== e.target) {
+          element.removeAttribute('selected');
         } else {
-          tab.setAttribute('selected', '');
-          setVisibleTabPanel(tab._props.controls);
-        }
+          element.setAttribute('selected', '');
+        } 
       });
+      setVisibleTabPanel(tabPanelIdentifier);
     });
   });
 });


### PR DESCRIPTION
This PR changes BaksTabListW to rely on attributes instead of ._props provided by vue. By relying on actual attributes it is much easier and clearer logic for showing/hiding tabs and tabspanel. Furthermore this also removes own custom typescript to make the compiler happy with HTMLElements.