### PR TITLE
refactor(BaksTabList): rename slot and component name

### DIFF
--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
@@ -7,7 +7,7 @@
       <slot></slot>
     </div>
     <div id="panels-container">
-      <slot name="panel"></slot>
+      <slot name="panels"></slot>
     </div>
   </div>
 </template>

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
@@ -22,7 +22,7 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-register(['BaksTabListW', 'BaksTab', 'BaksTabPanel']);
+register(['BaksTabList', 'BaksTab', 'BaksTabPanel']);
 
 export const Normal: Story = {
   args: {
@@ -30,7 +30,7 @@ export const Normal: Story = {
     variant: 'primary'
   },
   render: ({ direction, variant }) => {
-    return html`     <baks-tab-list-w direction="${direction}">
+    return html`     <baks-tab-list direction="${direction}">
       <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" selected>
         Test 1
       </baks-tab>
@@ -40,12 +40,12 @@ export const Normal: Story = {
       <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel3" role="tab">
         Test 3
       </baks-tab>
-      <div slot="panel">
+      <div slot="panels">
         <baks-tab-panel id="sidebar-log-tabpanel" role="tabpanel">Hello</baks-tab-panel>
         <baks-tab-panel id="sidebar-log-tabpanel2" role="tabpanel">2</baks-tab-panel>
         <baks-tab-panel id="sidebar-log-tabpanel3" role="tabpanel">3</baks-tab-panel>
       </div>
-    </baks-tab-list-w>`;
+    </baks-tab-list>`;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/web-components/lib/index.ts
+++ b/packages/web-components/lib/index.ts
@@ -6,7 +6,7 @@ import BaksCardCe from './components/baks-card/BaksCard.ce.vue';
 import BaksAccordion from 'baks-components-vue/lib/components/baks-accordion/BaksAccordion.vue';
 import BaksTab from 'baks-components-vue/lib/components/baks-tabs/BaksTab.vue';
 import BaksTabPanel from 'baks-components-vue/lib/components/baks-tabs/BaksTabPanel.vue';
-import BaksTabList from './components/baks-tabs/BaksTabsListW.ce.vue';
+import BaksTabList from './components/baks-tabs/BaksTabsList.ce.vue';
 export type { ThemeVariant as ThemeVariants } from 'baks-components-styles';
 
 
@@ -30,7 +30,7 @@ export type Components =
   | 'BaksCard'
   | 'BaksAccordion'
   | 'BaksTab'
-  | 'BaksTabListW'
+  | 'BaksTabList'
   | 'BaksTabPanel';
 
 export function register(specificComponents: Components[] = []) {
@@ -39,7 +39,7 @@ export function register(specificComponents: Components[] = []) {
     registerComponent('baks-accordion', BaksAccordionCE);
     registerComponent('baks-tab', BaksTabCE);
     registerComponent('baks-tab-panel', BaksTabPanelCe);
-    registerComponent('baks-tab-list-w', BaksTabListW);
+    registerComponent('baks-tab-list', BaksTabListW);
   } else {
     specificComponents.forEach((component) => {
       switch (component) {
@@ -55,8 +55,8 @@ export function register(specificComponents: Components[] = []) {
         case 'BaksTabPanel':
           registerComponent('baks-tab-panel', BaksTabPanelCe);
           break;
-        case 'BaksTabListW':
-          registerComponent('baks-tab-list-w', BaksTabListW);
+        case 'BaksTabList':
+          registerComponent('baks-tab-list', BaksTabListW);
           break;
       }
     });


### PR DESCRIPTION
This PR renames slot in BaksTabList to make the naming more consistent. The previous name "panel" indicated that there could only be 1 panel while the new name suggest it can be multiple.  It also renames the entire component which previously had a suffix of 'W' to make it more consistent with other component names.