### PR TITLE
fix(BaksTabPanel): remove default styling

### DIFF
--- a/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
@@ -1,20 +1,17 @@
 <template>
   <div
-    v-if="isVisible"
-    class="bk-tab-panel p-4 rounded rounded-t-none shadow-sm shadow-black"
     part="bk-tab-panel"
-    :class="resolveVariant(variant)"
+    role="tabpanel"
+    class="p-4"
+    :class="{ hidden: !props.isVisible }"
   >
     <slot></slot>
   </div>
 </template>
 
 <script setup lang="ts">
-import { resolveVariant } from 'baks-components-styles';
-import type { ThemeVariant } from 'baks-components-styles';
 
 interface Props {
-  variant: ThemeVariant;
   isVisible?: boolean;
 }
 


### PR DESCRIPTION
Removes variant prop to no longer render bakstabpanel with default styling

BREAKING CHANGE: Variant is no longer applicable to BaksTabPanel