### PR TITLE
Baks components web/feature/baks tab list accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage
 *.tsbuildinfo
 
 *storybook.log
+.nx

--- a/packages/vue-components/index.html
+++ b/packages/vue-components/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Testing playground</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/packages/vue-components/lib/components/baks-tabs/BaksTab.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTab.vue
@@ -4,9 +4,10 @@
     class="bk-tab block text-center rounded hover min-w-16 w-28 p-3"
     :class="[resolveVariant(variant), { 'is-selected': isSelected }]"
     part="bk-tab"
-    @click="handleClick"
     ref="element"
     :aria-controls="controls"
+    :aria-selected="isSelected"
+    role="tab"
   >
     <slot></slot>
   </button>
@@ -21,7 +22,7 @@ interface Props {
   variant: ThemeVariant;
   tabGroup: string;
   selected?: boolean;
-  controls?: string;
+  controls: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -39,15 +40,6 @@ watch(
 
 const element = ref<HTMLElement | null>(null);
 
-const handleClick = () => {
-  element.value?.dispatchEvent(
-    new CustomEvent('bk:click', {
-      detail: { tabGroup: props.tabGroup },
-      bubbles: true,
-      composed: true
-    })
-  );
-};
 </script>
 
 <style>

--- a/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
@@ -4,6 +4,8 @@
     role="tabpanel"
     class="p-4"
     :class="{ hidden: !props.isVisible }"
+    :aria-labelledby="controlledBy"
+    :id="($attrs.id as string)"
   >
     <slot></slot>
   </div>
@@ -13,6 +15,7 @@
 
 interface Props {
   isVisible?: boolean;
+  controlledBy: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
@@ -1,20 +1,17 @@
 <template>
   <div
-    v-if="isVisible"
-    class="bk-tab-panel p-4 rounded rounded-t-none shadow-sm shadow-black"
     part="bk-tab-panel"
-    :class="resolveVariant(variant)"
+    role="tabpanel"
+    class="p-4"
+    :class="{ hidden: !props.isVisible }"
   >
     <slot></slot>
   </div>
 </template>
 
 <script setup lang="ts">
-import { resolveVariant } from 'baks-components-styles';
-import type { ThemeVariant } from 'baks-components-styles';
 
 interface Props {
-  variant: ThemeVariant;
   isVisible?: boolean;
 }
 

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
@@ -2,12 +2,11 @@
   <div
     class="bk-tabs-list-w"
     ref="tabsWrapper"
-    part="bk-tabs-list-w" :class="direction">
-    <div class="bk-tabs border-none" :class="direction" part="bk-tabs">
+    part="bk-tabs-list-w" :class="direction"
+    role="tablist"
+    >
+    <div class="bk-tabs border-none" :class="direction" part="bk-tabs" role="none presentation">
       <slot></slot>
-    </div>
-    <div id="panels-container">
-      <slot name="panels"></slot>
     </div>
   </div>
 </template>

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
@@ -5,9 +5,7 @@
     part="bk-tabs-list-w" :class="direction"
     role="tablist"
     >
-    <div class="bk-tabs border-none" :class="direction" part="bk-tabs" role="none presentation">
       <slot></slot>
-    </div>
   </div>
 </template>
 
@@ -60,8 +58,10 @@ onMounted(() => {
     if (index % 2 == 0) {
       tab.classList.add(props.direction);
       tab.classList.add('special');
-      if (tabs.value.length === index - 1) {
+      if (tabs.value.length - 1 === index) {
         tab.classList.add('last');
+      } else if(index === 0) {
+        tab.classList.add('first');
       }
     }
 
@@ -104,22 +104,11 @@ onMounted(() => {
   border-bottom: none;
 }
 
-.bk-tabs {
-  display: flex;
-  flex-direction: column;
-}
-.bk-tabs.horizontal {
-  flex-direction: row;
-}
-
 .bk-tabs-list-w {
   display: flex;
-  flex-direction: row;
-}
-.bk-tabs-list-w.horizontal {
   flex-direction: column;
 }
-#panels-container {
-  flex-grow: 1;
+.bk-tabs-list-w.horizontal {
+  flex-direction: row;
 }
 </style>

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
@@ -26,27 +26,23 @@ register(['BaksTabList', 'BaksTab', 'BaksTabPanel']);
 
 export const Normal: Story = {
   args: {
-    direction: 'horizontal',
+    direction: "vertical",
     variant: 'primary'
   },
   render: ({ direction, variant }) => {
     return html`
     <div class="flex flex-col">
       <baks-tab-list direction="${direction}" role="tablist">
-        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" selected>
+        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" id="tab1">
           Test 1
         </baks-tab>
-        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel2" role="tab">
+        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel2" role="tab" id="tab2" selected>
           Test 2
-        </baks-tab>
-        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel3" role="tab">
-          Test 3
         </baks-tab>
       </baks-tab-list>
       <div>
-          <baks-tab-panel id="sidebar-log-tabpanel" role="tabpanel">Hello</baks-tab-panel>
-          <baks-tab-panel id="sidebar-log-tabpanel2" role="tabpanel">2</baks-tab-panel>
-          <baks-tab-panel id="sidebar-log-tabpanel3" role="tabpanel">3</baks-tab-panel>
+          <baks-tab-panel id="sidebar-log-tabpanel" controlled-by="tab1" role="tabpanel">Hello</baks-tab-panel>
+          <baks-tab-panel id="sidebar-log-tabpanel2" controlled-by="tab2" role="tabpanel">2</baks-tab-panel>
       </div>
     </div>
     `;

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.stories.ts
@@ -30,22 +30,26 @@ export const Normal: Story = {
     variant: 'primary'
   },
   render: ({ direction, variant }) => {
-    return html`     <baks-tab-list direction="${direction}">
-      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" selected>
-        Test 1
-      </baks-tab>
-      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel2" role="tab">
-        Test 2
-      </baks-tab>
-      <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel3" role="tab">
-        Test 3
-      </baks-tab>
-      <div slot="panels">
-        <baks-tab-panel id="sidebar-log-tabpanel" role="tabpanel">Hello</baks-tab-panel>
-        <baks-tab-panel id="sidebar-log-tabpanel2" role="tabpanel">2</baks-tab-panel>
-        <baks-tab-panel id="sidebar-log-tabpanel3" role="tabpanel">3</baks-tab-panel>
+    return html`
+    <div class="flex flex-col">
+      <baks-tab-list direction="${direction}" role="tablist">
+        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel" role="tab" selected>
+          Test 1
+        </baks-tab>
+        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel2" role="tab">
+          Test 2
+        </baks-tab>
+        <baks-tab variant="${variant}" tab-group="sidebar-tab" controls="sidebar-log-tabpanel3" role="tab">
+          Test 3
+        </baks-tab>
+      </baks-tab-list>
+      <div>
+          <baks-tab-panel id="sidebar-log-tabpanel" role="tabpanel">Hello</baks-tab-panel>
+          <baks-tab-panel id="sidebar-log-tabpanel2" role="tabpanel">2</baks-tab-panel>
+          <baks-tab-panel id="sidebar-log-tabpanel3" role="tabpanel">3</baks-tab-panel>
       </div>
-    </baks-tab-list>`;
+    </div>
+    `;
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/web-components/tailwind.config.ts
+++ b/packages/web-components/tailwind.config.ts
@@ -5,7 +5,7 @@ export default {
     './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}',
     './src/**/*.{js,jsx,ts,tsx,vue,ce.vue}',
     './index.html',
-    '../../node_modules/@baks-components/vue/lib/components/**/*.{js,jsx,ts,tsx,vue,ce.vue}'
+    '../../node_modules/baks-components-vue/lib/components/**/*.{js,jsx,ts,tsx,vue,ce.vue}'
   ],
   theme: {
     extend: {}


### PR DESCRIPTION
When using axe devtools I discovered that role="tablist" doesn't allow for descendants with othe roles like "tabpanel". The current implementation of the component therefore violates aria. 

This PR aims to fix that by removing the slot for the TabPanels. 