### PR TITLE
fix(BaksCard): missing bk-card classname

### DIFF
--- a/packages/vue-components/lib/components/baks-card/BaksCard.vue
+++ b/packages/vue-components/lib/components/baks-card/BaksCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     part="baks-card"
-    class="relative p-4 rounded shadow-sm shadow-black"
+    class="bk-card relative p-4 rounded shadow-sm shadow-black"
     :class="resolveVariant(variant)"
   >
     <slot></slot>


### PR DESCRIPTION
Missing bk-card class made applying own styles very difficult.