### PR TITLE
feat(BaksButton): add default value for button type

### DIFF
--- a/packages/vue-components/lib/components/baks-button/BaksButton.vue
+++ b/packages/vue-components/lib/components/baks-button/BaksButton.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    :type
     part="bk-button"
     class="bk-button hover shadow-sm shadow-black px-6 py-1.5 cursor-pointer rounded min-w-24"
     :class="[resolveVariant(variant), { 'w-full': size === 'block', disabled: disabled }]"
@@ -12,12 +13,14 @@
 import { type ThemeVariant, resolveVariant } from 'baks-components-styles';
 
 interface Props {
+  type?: 'button' | 'submit' | 'reset';
   variant: ThemeVariant;
   size?: 'normal' | 'block';
   disabled?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  type: 'button',
   size: 'normal',
   disabled: false
 });


### PR DESCRIPTION
This PR adds a default type to the button.
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
The default type is 'submit' which could be unexpected for quite some users.