### PR TITLE
fix(variant): invalid variable value for base-dark-text-color

### DIFF
--- a/packages/shared/src/css/variant.css
+++ b/packages/shared/src/css/variant.css
@@ -2,7 +2,7 @@
   :host,
   :root {
     --base-light-text-color: theme(colors.gray.50);
-    --base-dark-text-color: '#1f2937';
+    --base-dark-text-color: #1f2937;
     --box-shadow: 0 0 3px 2px;
 
     --primary-color: theme(colors.sky.500);


### PR DESCRIPTION
Plain and simple fix. The color was wrongly put in single qoutes causing color to not be applied.