### PR TITLE
refactor: Use stroke styling from baks-components-styles

### DIFF
--- a/packages/vue-components/lib/components/Icons/ChevronDown.vue
+++ b/packages/vue-components/lib/components/Icons/ChevronDown.vue
@@ -12,6 +12,7 @@
   >
     <path
       d="M6 9L12 15L18 9"
+      class="stroke"
       stroke="#000000"
       stroke-width="2"
       stroke-linecap="round"

--- a/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
+++ b/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
@@ -115,17 +115,6 @@ const toggleIsOpen = () => {
   }
 }
 
-.bk-dark,
-.bk-error,
-.bk-secondary,
-.bk-success,
-.bk-info,
-.bk-primary {
-  .chevron-down path {
-    stroke: var(--base-light-text-color);
-  }
-}
-
 .bk-accordion-content {
   transition: all 0.3s ease-out;
 }


### PR DESCRIPTION
This PR removes the stroke rule applied in BaksAccordion on ChevronDown. With the new bk-icon styling to baks-components-styles this becomes duplicated code which then can be removed.