### PR TITLE
fix(baks-components-styles): tailwind reference and theme variables

### DIFF
--- a/packages/shared/src/css/baks-button.css
+++ b/packages/shared/src/css/baks-button.css
@@ -1,4 +1,4 @@
-@reference './variant.css';
+@reference 'baks-components-styles/src/css/variant.css';
 
 @layer components {
   .bk-button {

--- a/packages/shared/src/css/baks-select.css
+++ b/packages/shared/src/css/baks-select.css
@@ -1,4 +1,4 @@
-@reference './variant.css';
+@reference 'baks-components-styles/src/css/variant.css';
 
 @layer components {
   .bk-select {

--- a/packages/shared/src/css/baks-tab.css
+++ b/packages/shared/src/css/baks-tab.css
@@ -1,4 +1,4 @@
-@reference './variant.css';
+@reference 'baks-components-styles/src/css/variant.css';
 .bk-tab {
   @apply min-w-16;
   @apply w-28;

--- a/packages/shared/src/css/variant.css
+++ b/packages/shared/src/css/variant.css
@@ -1,63 +1,63 @@
 @reference 'tailwindcss';
 @theme {
-    --base-light-text-color: theme(colors.gray.50);
+    --base-light-text-color: var(--color-gray-50);
     --base-dark-text-color: #1f2937;
     --box-shadow: 0 0 3px 2px;
 
-    --primary-color: theme(colors.sky.500);
-    --primary-color-hover: theme(colors.sky.600);
-    --primary-color-focus: theme(colors.sky.600);
-    --primary-color-active: theme(colors.sky.600);
-    --primary-color-border: theme(colors.sky.600);
+    --primary-color: var(--color-sky-500);
+    --primary-color-hover: var(--color-sky-600);
+    --primary-color-focus: var(--color-sky-600);
+    --primary-color-active: var(--color-sky-600);
+    --primary-color-border: var(--color-sky-600);
     --primary-color-text: var(--base-light-text-color);
 
-    --secondary-color: theme(colors.orange.600);
-    --secondary-color-hover: theme(colors.orange.700);
-    --secondary-color-focus: theme(colors.orange.700);
-    --secondary-color-active: theme(colors.orange.700);
-    --secondary-color-border: theme(colors.orange.700);
+    --secondary-color: var(--color-orange-600);
+    --secondary-color-hover: var(--color-orange-700);
+    --secondary-color-focus: var(--color-orange-700);
+    --secondary-color-active: var(--color-orange-700);
+    --secondary-color-border: var(--color-orange-700);
     --secondary-color-text: var(--base-light-text-color);
 
-    --dark-color: theme(colors.gray.600);
-    --dark-color-hover: theme(colors.gray.700);
-    --dark-color-focus: theme(colors.gray.700);
-    --dark-color-active: theme(colors.gray.700);
-    --dark-color-border: theme(colors.gray.700);
+    --dark-color: var(--color-gray-600);
+    --dark-color-hover: var(--color-gray-700);
+    --dark-color-focus: var(--color-gray-700);
+    --dark-color-active: var(--color-gray-700);
+    --dark-color-border: var(--color-gray-700);
     --dark-color-text: var(--base-light-text-color);
 
-    --light-color: theme(colors.gray.200);
-    --light-color-hover: theme(colors.gray.300);
-    --light-color-focus: theme(colors.gray.300);
-    --light-color-active: theme(colors.gray.300);
-    --light-color-border: theme(colors.gray.300);
+    --light-color: var(--color-gray-200);
+    --light-color-hover: var(--color-gray-300);
+    --light-color-focus: var(--color-gray-300);
+    --light-color-active: var(--color-gray-300);
+    --light-color-border: var(--color-gray-300);
     --light-color-text: var(--base-dark-text-color);
 
-    --success-color: theme(colors.green.600);
-    --success-color-hover: theme(colors.green.700);
-    --success-color-focus: theme(colors.green.700);
-    --success-color-active: theme(colors.green.700);
-    --success-color-border: theme(colors.green.700);
+    --success-color: var(--color-green-600);
+    --success-color-hover: var(--color-green-700);
+    --success-color-focus: var(--color-green-700);
+    --success-color-active: var(--color-green-700);
+    --success-color-border: var(--color-green-700);
     --success-color-text: var(--base-light-text-color);
 
-    --error-color: theme(colors.red.600);
-    --error-color-hover: theme(colors.red.700);
-    --error-color-focus: theme(colors.red.700);
-    --error-color-active: theme(colors.red.700);
-    --error-color-border: theme(colors.red.700);
+    --error-color: var(--color-red-600);
+    --error-color-hover: var(--color-red-700);
+    --error-color-focus: var(--color-red-700);
+    --error-color-active: var(--color-red-700);
+    --error-color-border: var(--color-red-700);
     --error-color-text: var(--base-light-text-color);
 
-    --info-color: theme(colors.blue.500);
-    --info-color-hover: theme(colors.blue.600);
-    --info-color-focus: theme(colors.blue.600);
-    --info-color-active: theme(colors.blue.600);
-    --info-color-border: theme(colors.blue.600);
+    --info-color: var(--color-blue-500);
+    --info-color-hover: var(--color-blue-600);
+    --info-color-focus: var(--color-blue-600);
+    --info-color-active: var(--color-blue-600);
+    --info-color-border: var(--color-blue-600);
     --info-color-text: var(--base-light-text-color);
 
-    --warning-color: theme(colors.yellow.500);
-    --warning-color-hover: theme(colors.yellow.600);
-    --warning-color-focus: theme(colors.yellow.600);
-    --warning-color-active: theme(colors.yellow.600);
-    --warning-color-border: theme(colors.yellow.600);
+    --warning-color: var(--color-yellow-500);
+    --warning-color-hover: var(--color-yellow-600);
+    --warning-color-focus: var(--color-yellow-600);
+    --warning-color-active: var(--color-yellow-600);
+    --warning-color-border: var(--color-yellow-600);
     --warning-color-text: var(--base-dark-text-color);
 }
 


### PR DESCRIPTION
This PR adresses two issues encountered when using the library.
* The relative reference to variant.css was not found when baks-components-vue & baks-components-web was built
* The theme function is depreceated and caused and theme function not being found when built