### PR TITLE
fix(baks-components-styles): use static to prevent removal of theme variables

### DIFF
--- a/packages/shared/src/css/variant.css
+++ b/packages/shared/src/css/variant.css
@@ -1,5 +1,5 @@
 @reference 'tailwindcss';
-@theme {
+@theme static {
     --base-light-text-color: var(--color-gray-50);
     --base-dark-text-color: #1f2937;
     --box-shadow: 0 0 3px 2px;


### PR DESCRIPTION
When not using the `static` values would be removed. This make sure that theme variables is available.