### PR TITLE
fix(baks-components-vue): prevent duplicate tailwind styling

### DIFF
--- a/packages/vue-components/app.css
+++ b/packages/vue-components/app.css
@@ -2,5 +2,6 @@
 @import 'tailwindcss';
 @import '../shared/src/css/variant.css';
 
+@source '../shared/src/css/variant.css';
 @source './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}';
 @source './src/**/*.{js,jsx,ts,tsx,vue,ce.vue}';

--- a/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
+++ b/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
@@ -93,7 +93,6 @@ const toggleIsOpen = () => {
 </script>
 
 <style>
-@import url('../../app.css');
 .bk-accordion.expanded {
   &.bk-primary .bk-accordion-header {
     border-color: var(--primary-color-border);

--- a/packages/vue-components/lib/components/baks-card/BaksCard.vue
+++ b/packages/vue-components/lib/components/baks-card/BaksCard.vue
@@ -16,7 +16,3 @@ interface Props {
 }
 const props = defineProps<Props>();
 </script>
-
-<style>
-@import url('../../app.css');
-</style>

--- a/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
@@ -22,7 +22,3 @@ const props = withDefaults(defineProps<Props>(), {
   isVisible: false
 });
 </script>
-
-<style>
-@import url('../../app.css');
-</style>


### PR DESCRIPTION
Tailwind was imported several times which caused duplicate styling. This PR introduces changes to address that by removing some css imports.