### PR TITLE
fix(baks-components-web): fix missing style from compiled stylesheet

### DIFF
--- a/packages/web-components/lib/app.css
+++ b/packages/web-components/lib/app.css
@@ -4,4 +4,4 @@
 @source './src/**/*.{js,jsx,ts,tsx,vue,ce.vue}';
 @source './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}';
 @source './index.html';
-@source '../../node_modules/baks-components-vue/lib/components/**/*.{js,jsx,ts,tsx,vue,ce.vue}';
+@source '../../vue-components/lib/components/**/*.{js,jsx,ts,tsx,vue,ce.vue}';


### PR DESCRIPTION
Wrong path in source caused style not being picked up by tailwind and missed in stylesheet. example `p-3`was missing for baksTab