### PR TITLE
build!: add entrypoints and vite input

### DIFF
--- a/packages/vue-components/package.json
+++ b/packages/vue-components/package.json
@@ -15,6 +15,12 @@
     "type": "git",
     "url": "git+https://github.com/Tjaitil/baks-components.git"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./style.css": "./dist/index.css",
+    "./themes/default.css": "./dist/themes/default.css",
+    "./lib/*": "./lib/*"
+  },
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" -- && npm run types",

--- a/packages/vue-components/vite.config.ts
+++ b/packages/vue-components/vite.config.ts
@@ -19,6 +19,7 @@ export default mergeConfig(rootConfig, defineConfig({
     }
   },
   build: {
+    cssCodeSplit: true,
     copyPublicDir: false,
     lib: {
       entry: resolve(__dirname, 'lib/index.ts'),
@@ -33,6 +34,10 @@ export default mergeConfig(rootConfig, defineConfig({
         entryFileNames(chunkInfo) {
           return `${chunkInfo.name}.js`;
         }
+      },
+      input: {
+        'index': resolve(__dirname, 'lib/index.ts'),
+        'themes/default.css': '@shared/css/themes/default.css',
       }
     }
   }


### PR DESCRIPTION
Adds entrypoints and vite input for exporting themes from `baks-components-styles"

BREAKING CHANGE: Imports from package needs to be updated