### PR TITLE
refactor(baks-components-styles): remove unecessary reference paths to variant.css

### DIFF
--- a/packages/shared/src/css/baks-button.css
+++ b/packages/shared/src/css/baks-button.css
@@ -1,4 +1,4 @@
-@reference 'baks-components-styles/src/css/variant.css';
+@reference 'tailwindcss';
 
 @layer components {
   .bk-button {

--- a/packages/shared/src/css/baks-select.css
+++ b/packages/shared/src/css/baks-select.css
@@ -1,4 +1,4 @@
-@reference 'baks-components-styles/src/css/variant.css';
+@reference 'tailwindcss';
 
 @layer components {
   .bk-select {

--- a/packages/shared/src/css/baks-tab.css
+++ b/packages/shared/src/css/baks-tab.css
@@ -1,4 +1,4 @@
-@reference 'baks-components-styles/src/css/variant.css';
+@reference 'tailwindcss';
 .bk-tab {
   @apply min-w-16;
   @apply w-28;

--- a/packages/shared/src/css/variant.css
+++ b/packages/shared/src/css/variant.css
@@ -1,5 +1,3 @@
-@reference 'tailwindcss';
-
 @layer components {
   .bk-primary,
   .bk-secondary,
@@ -10,7 +8,8 @@
   .bk-warning,
   .bk-info {
     font-family: sans-serif;
-    @apply border-2;
+    border-style: solid;
+    border-width: 2px;
   }
 
   .bk-primary {
@@ -288,7 +287,7 @@
     :disabled,
     &.disabled,
     &:disabled {
-      @apply brightness-[0.80];
+      filter: brightness(0.8);
       cursor: initial;
     }
   }


### PR DESCRIPTION
This PR aims to remove unecessary reference with paths to `variant.css`. This is not necessary. The theme variables are not located in said file. If needed to access theme variable one could use the css theme variables provided by tailwind.