### PR TITLE
feat(baks-components-vue): add @source to scan dist folder

### DIFF
--- a/packages/vue-components/lib/app.css
+++ b/packages/vue-components/lib/app.css
@@ -1,1 +1,4 @@
 @import url('../../shared/src/css/variant.css');
+
+@source '../shared/src/css/variant.css';
+@source './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}';

--- a/packages/vue-components/lib/app.css
+++ b/packages/vue-components/lib/app.css
@@ -1,4 +1,3 @@
 @import url('../../shared/src/css/variant.css');
 
-@source '../shared/src/css/variant.css';
 @source './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}';

--- a/packages/vue-components/lib/app.css
+++ b/packages/vue-components/lib/app.css
@@ -1,3 +1,3 @@
 @import url('../../shared/src/css/variant.css');
 
-@source './lib/**/*.{js,jsx,ts,tsx,vue,ce.vue}';
+@source '../dist';


### PR DESCRIPTION
This PR adds the `@source` directive to the `app.css. The consumer doesn't need to add a `@source` to the `node_modules` folder to pick up styles only present in components in this repo