### PR TITLE
fix(BaksSelect)!: various ay11 issues, remove includeEmptyOption and missing export

### DIFF
--- a/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
@@ -203,7 +203,9 @@ describe('BaksSelect', () => {
         return { selected, options: defaultOptions };
       },
       template: `
-        <BaksSelect v-model="selected" :options="options" name="test-select" variant="primary" selectLabel="Choose an option" />
+        <label for="test-select" id="test-select-label">Test Select</label>
+        <BaksSelect v-model="selected" :options="options" name="test-select" variant="primary" selectLabel="Choose an option"
+          aria-labelledby="test-select-label" />
         <span data-testid="selected">{{ selected }}</span>
       `
     });

--- a/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
@@ -204,7 +204,7 @@ describe('BaksSelect', () => {
       },
       template: `
         <label for="test-select" id="test-select-label">Test Select</label>
-        <BaksSelect v-model="selected" :options="options" name="test-select" variant="primary" selectLabel="Choose an option"
+        <BaksSelect v-model="selected" :options="options" id="test-select" name="test-select" variant="primary" selectLabel="Choose an option"
           aria-labelledby="test-select-label" />
         <span data-testid="selected">{{ selected }}</span>
       `

--- a/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
@@ -251,7 +251,7 @@ describe('BaksSelect', () => {
       { value: 'cherry', label: 'Cherry' }
     ];
 
-    const props = { ...defaultProps, options, modelValuew: 'apple' };
+    const props = { ...defaultProps, options, modelValue: 'apple' };
     render(BaksSelect, { props });
 
     const selectElement = screen.getByRole('combobox');

--- a/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.test.ts
@@ -1,0 +1,313 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import BaksSelect from './BaksSelect.vue';
+import { defineComponent, ref } from 'vue'; // Used in v-model test
+import type { ThemeVariant } from 'baks-components-styles';
+
+// Mock the isClippingOutside utility
+vi.mock('@/lib/isClippingOutside', () => ({
+  isClippingOutside: vi.fn(() => ({
+    isOutside: false,
+    isClippingTop: false,
+    isClippingBottom: false,
+    isClippingRight: false,
+    sides: { top: 0, bottom: 0, left: 0, right: 0 }
+  }))
+}));
+
+// Mock the styles module
+vi.mock('baks-components-styles', () => ({
+  resolveVariant: vi.fn((variant: string) => `variant-${variant}`)
+}));
+
+const defaultOptions = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' }
+];
+
+const defaultProps = {
+  id: 'test-select',
+  'aria-labelledby': 'test-label',
+  name: 'test-select',
+  variant: 'primary' as ThemeVariant,
+  options: defaultOptions,
+  selectLabel: 'Choose an option'
+};
+
+describe('BaksSelect', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  test('renders with default props', () => {
+    render(BaksSelect, { props: defaultProps });
+    // By default, selectLabel is shown
+    expect(screen.getByText('Choose an option')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  test('shows select label when selectLabel is provided', () => {
+    render(BaksSelect, {
+      props: {
+        ...defaultProps,
+        selectLabel: 'Choose an option'
+      }
+    });
+    expect(screen.getByText('Choose an option')).toBeInTheDocument();
+  });
+
+  test('opens dropdown when clicked', async () => {
+    render(BaksSelect, { props: defaultProps });
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
+
+  test('selects option when clicked', async () => {
+    render(BaksSelect, { props: { ...defaultProps, modelValue: 'option1' } });
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+    const option2List = screen.getAllByText('Option 2');
+    const option2 = option2List[option2List.length - 1];
+    expect(option2).toBeTruthy();
+    await user.click(option2);
+    await waitFor(() => {
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+  test('closes dropdown when option is selected', async () => {
+    render(BaksSelect, { props: defaultProps });
+
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    const option2 = screen.getAllByText('Option 2')[1];
+    await user.click(option2);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('navigates options with arrow keys', async () => {
+    render(BaksSelect, { props: defaultProps });
+
+    const selectElement = screen.getByRole('combobox');
+    selectElement.focus();
+
+    // Open dropdown with ArrowDown
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Navigate down
+    await user.keyboard('{ArrowDown}');
+    const highlightedOption = screen.getByRole('option', { name: /Option 2/i });
+    expect(highlightedOption).toHaveClass('is-highlighted');
+
+    // Navigate up
+    await user.keyboard('{ArrowUp}');
+    const firstOption = screen.getByRole('option', { name: /Option 1/i });
+    expect(firstOption).toHaveClass('is-highlighted');
+  });
+
+  test('selects highlighted option with Enter key', async () => {
+    render(BaksSelect, { props: defaultProps });
+    const selectElement = screen.getByRole('combobox');
+    selectElement.focus();
+    await user.keyboard('{ArrowDown}'); // Open dropdown
+    await user.keyboard('{ArrowDown}'); // Navigate to Option 2
+    await user.keyboard('{Enter}'); // Select Option 2
+    await waitFor(() => {
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('closes dropdown with Escape key', async () => {
+    render(BaksSelect, { props: defaultProps });
+
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('searches options by typing', async () => {
+    const options = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana' },
+      { value: 'cherry', label: 'Cherry' }
+    ];
+
+    render(BaksSelect, {
+      props: {
+        ...defaultProps,
+        options
+      }
+    });
+
+    const selectElement = screen.getByRole('combobox');
+    selectElement.focus();
+
+    await user.keyboard('{ArrowDown}'); // Open dropdown
+    await user.keyboard('b'); // Search for 'b'
+
+    const bananaOption = screen.getByRole('option', { name: /Banana/i });
+    expect(bananaOption).toHaveClass('is-highlighted');
+  });
+
+  test('handles disabled state', async () => {
+    render(BaksSelect, {
+      props: defaultProps,
+      attrs: { disabled: true }
+    });
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveAttribute('aria-disabled', 'true');
+    expect(selectElement).toHaveClass('disabled');
+
+    await user.click(selectElement);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('shows checkmark for selected option', async () => {
+    render(BaksSelect, {
+      props: { ...defaultProps, selectLabel: 'Select', modelValue: 'option1' }
+    });
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+    // First option should be selected by default and show checkmark
+    const firstOptionRow = screen.getByRole('option', { name: /Option 1/i });
+    expect(firstOptionRow.querySelector('.checkmark-icon-wrapper svg')).not.toBeNull();
+  });
+
+  test('updates selected option with v-model', async () => {
+    const TestWrapper = defineComponent({
+      components: { BaksSelect },
+      setup() {
+        const selected = ref('option1');
+        return { selected, options: defaultOptions };
+      },
+      template: `
+        <BaksSelect v-model="selected" :options="options" name="test-select" variant="primary" selectLabel="Choose an option" />
+        <span data-testid="selected">{{ selected }}</span>
+      `
+    });
+    const result = render(TestWrapper);
+    expect(result.getByTestId('selected')).toHaveTextContent('option1');
+    await user.click(result.getByRole('combobox'));
+    const option3List = result.getAllByText('Option 3');
+    const option3 = option3List[option3List.length - 1];
+    expect(option3).toBeTruthy();
+    await user.click(option3);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.getByTestId('selected')).toHaveTextContent('option3');
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
+
+  test('handles mouse hover on options', async () => {
+    render(BaksSelect, { props: defaultProps });
+
+    const selectElement = screen.getByRole('combobox');
+    await user.click(selectElement);
+
+    const option2 = screen.getByRole('option', { name: /Option 2/i });
+    await user.hover(option2);
+
+    expect(option2).toHaveClass('is-highlighted');
+  });
+
+  test('closes dropdown on Tab key and selects highlighted option', async () => {
+    render(BaksSelect, { props: defaultProps });
+    const selectElement = screen.getByRole('combobox');
+    selectElement.focus();
+    await user.keyboard('{ArrowDown}'); // Open dropdown
+    await user.keyboard('{ArrowDown}'); // Navigate to Option 2
+    await user.keyboard('{Tab}'); // Tab should close and select
+
+    await waitFor(() => {
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+    });
+  });
+
+  test('applies correct ARIA attributes', async () => {
+    const options = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'banana', label: 'Banana' },
+      { value: 'cherry', label: 'Cherry' }
+    ];
+
+    const props = { ...defaultProps, options, modelValuew: 'apple' };
+    render(BaksSelect, { props });
+
+    const selectElement = screen.getByRole('combobox');
+
+    expect(selectElement).toHaveAttribute('aria-label', defaultProps.selectLabel);
+    expect(selectElement).toHaveAttribute('aria-expanded', 'false');
+    expect(selectElement).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(selectElement).toHaveAttribute('aria-controls');
+
+    await user.click(selectElement);
+
+    expect(selectElement).toHaveAttribute('aria-expanded', 'true');
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveAttribute('id');
+
+    const optionsElements = screen.getAllByRole('option');
+    const option = optionsElements.find((option) => {
+      return option.textContent === 'Apple';
+    });
+    if (!option) {
+      throw new Error('Option "Apple" not found');
+    }
+    expect(option).toHaveAttribute('aria-selected', 'true');
+    expect(selectElement).toHaveAttribute('aria-activedescendant', option.id);
+  });
+
+  test('handles buffer search timeout', async () => {
+    const options = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'apricot', label: 'Apricot' },
+      { value: 'banana', label: 'Banana' }
+    ];
+    render(BaksSelect, {
+      props: {
+        ...defaultProps,
+        options
+      }
+    });
+    const selectElement = screen.getByRole('combobox');
+    selectElement.focus();
+    await user.keyboard('{ArrowDown}'); // Open dropdown
+    await user.keyboard('a'); // Search for 'a'
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /Apple/i })).toHaveClass('is-highlighted');
+    });
+    await user.keyboard('p'); // Continue typing 'ap'
+    await user.keyboard('r'); // Continue typing 'ap'
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /Apricot/i })).toHaveClass('is-highlighted');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await user.keyboard('b');
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /Banana/i })).toHaveClass('is-highlighted');
+    });
+  });
+});

--- a/packages/vue-components/lib/components/baks-select/BaksSelect.vue
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.vue
@@ -1,50 +1,55 @@
 <template>
   <div
+    ref="select-container"
     class="select-container bk-select shadow-xs shadow-black"
     :class="resolveVariant(variant)"
-    ref="select-container"
   >
-    <div
-      class="select-element cursor-pointer flex items-center justify-between focus apply-variant gap-x-2"
-      @click="toggleOpen"
+    <button
+      :id
+      ref="select-element"
+      class="select-element cursor-pointer flex items-center justify-between focus apply-variant gap-x-2 w-full"
       tabindex="0"
       :name="name"
       role="combobox"
-      aria-label="Select"
+      :aria-label="selectLabel"
+      :aria-labelledby="props['aria-labelledby']"
+      :aria-activedescendant="isOpen ? `${id}-option-${currentIndex}` : undefined"
       :aria-expanded="isOpen"
       aria-haspopup="listbox"
       :aria-controls="listboxId"
       :aria-disabled="isDisabled"
       :class="{ disabled: isDisabled }"
+      @click="toggleOpen"
       @keydown.prevent="handleKeyPress"
-      ref="select-element"
     >
-      <span class="select-none text-ellipsis overflow-hidden max-h-16">{{ getSelectedLabel }}</span>
+      <span class="select-none text-ellipsis overflow-hidden max-h-16">{{
+        selectedOption != undefined ? selectedOption.label : props.selectLabel
+      }}</span>
       <span class="select-none">
         <slot name="baks-select-icon">
           <ChevronDown class="stroke" />
         </slot>
       </span>
-    </div>
+    </button>
     <Transition name="slide-fade">
       <div
         v-if="isOpen"
-        class="absolute listbox-container"
         :id="listboxId"
-        role="listbox"
         ref="listbox"
+        class="absolute listbox-container"
+        role="listbox"
       >
         <div
           v-for="(option, index) in options"
+          :id="`${id}-option-${index}`"
           :key="option.value"
-          :value="option.value"
           class="flex listbox-item gap-x-2"
           :class="{ 'is-highlighted': currentIndex === index }"
-          :aria-activedescendant="index.toString()"
-          :aria-selected="currentIndex === index"
+          :aria-labelledby="props['aria-labelledby']"
+          :aria-selected="selected === option.value"
+          role="option"
           @click="setSelectedOption(option.value)"
           @mouseenter="currentIndex = index"
-          role="option"
         >
           <span class="checkmark-icon-wrapper">
             <slot name="checkmark icon">
@@ -71,39 +76,33 @@ import { isClippingOutside } from '@/lib/isClippingOutside';
 interface Option {
   value: string | number;
   label: string | number;
-  [key: string]: any;
 }
 
 interface Props {
+  id: string;
+  // eslint-disable-next-line vue/prop-name-casing
+  'aria-labelledby': string;
   name: string;
   variant: ThemeVariant;
   options: Option[];
-  includeEmptyOption?: boolean;
   selectLabel?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  includeEmptyOption: false
+  selectLabel: 'Select'
 });
+
 const attrs = useAttrs();
 const isDisabled = computed(() => attrs.disabled != null);
 
 const isOpen = ref(false);
 const selected = defineModel<Option['value'] | null>();
-const resolveInitialSelected = () => {
-  if (props.includeEmptyOption) {
-    return null;
-  }
-  return props.options[0].value;
-};
-const selecedOption = computed(() =>
+const selectedOption = computed(() =>
   props.options.find((option) => option.value === selected.value)
 );
-selected.value = resolveInitialSelected();
 
 const listboxId = useId();
-const listbox = useTemplateRef<HTMLElement>('listbox');
-const selectElement = useTemplateRef<HTMLElement>('select-element');
+const listboxElement = useTemplateRef<HTMLElement>('listbox');
 const selectElementContainer = useTemplateRef<HTMLElement>('select-container');
 onClickOutside(selectElementContainer, () => {
   isOpen.value = false;
@@ -114,17 +113,9 @@ const setSelectedOption = (key: Option['value']) => {
   isOpen.value = false;
 };
 const setSelectedOptionFromIndex = () => {
-  setSelectedOption(props.options[currentIndex.value].label);
+  setSelectedOption(props.options[currentIndex.value].value);
 };
 
-const getSelectedLabel = computed(() => {
-  if (selecedOption.value != null) {
-    return selecedOption.value.label;
-  } else if (props.selectLabel) {
-    return props.selectLabel;
-  }
-  return 'Select';
-});
 const toggleOpen = () => {
   if (isDisabled.value) return;
   isOpen.value = !isOpen.value;
@@ -188,15 +179,14 @@ const handleKeyPress = (event: KeyboardEvent) => {
 };
 
 const handleScroll = () => {
-  const element = <HTMLElement>listbox.value?.children[currentIndex.value];
-  if (element) {
-    const { isOutside, isClippingTop, isClippingBottom, sides } = isClippingOutside(
+  const element = listboxElement.value?.children[currentIndex.value];
+  if (element instanceof HTMLElement) {
+    const { isOutside, isClippingTop, isClippingBottom } = isClippingOutside(
       element,
-      listbox.value
+      listboxElement.value
     );
     if (isOutside && (isClippingTop || isClippingBottom)) {
       element.scrollIntoView({ block: 'nearest' });
-    } else {
     }
   }
 };
@@ -205,17 +195,17 @@ watch(
   () => isOpen.value,
   (newVal) => {
     if (newVal) {
-      nextTick(() => {
-        if (listbox.value == undefined) return;
+      void nextTick(() => {
+        if (listboxElement.value == undefined) return;
         const { isOutside, isClippingRight, isClippingBottom, sides } = isClippingOutside(
-          listbox.value
+          listboxElement.value
         );
         if (isOutside) {
           if (isClippingRight) {
-            listbox.value.style.left = `-${sides.right}px`;
+            listboxElement.value.style.left = `-${sides.right.toString()}px`;
           }
           if (isClippingBottom) {
-            listbox.value.style.top = `-${sides.bottom}px`;
+            listboxElement.value.style.top = `-${sides.bottom.toString()}px`;
           }
         }
       });

--- a/packages/vue-components/src/App.vue
+++ b/packages/vue-components/src/App.vue
@@ -1,26 +1,18 @@
 <template>
   <div>App</div>
-  <BaksSelect :options v-model="selected" name="test" variant="primary" />
   <BaksAccordion variant="primary">
-    <template #header>
-      Accordion
-    </template>
+    <template #header> Accordion </template>
     <template #content>
       <p>
-        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Harum iste, aliquid saepe, quo mollitia et laboriosam tempora, reprehenderit neque asperiores similique quis rerum quaerat molestias? Eaque odit nisi dignissimos suscipit.
+        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Harum iste, aliquid saepe, quo
+        mollitia et laboriosam tempora, reprehenderit neque asperiores similique quis rerum quaerat
+        molestias? Eaque odit nisi dignissimos suscipit.
       </p>
     </template>
   </BaksAccordion>
-  <div class="p-4 bg-red-50">
-    hello
-  </div>
+  <div class="p-4 bg-red-50">hello</div>
 </template>
 
 <script lang="ts" setup>
-import BaksAccordion from "@/components/baks-accordion/BaksAccordion.vue";
-import BaksSelect from "@/components/baks-select/BaksSelect.vue";
-import { ref } from "vue";
-
-const options = ref([{ label: "hello", value: "hello" }]);
-const selected = ref("hello");
+import BaksAccordion from '@/components/baks-accordion/BaksAccordion.vue';
 </script>


### PR DESCRIPTION
This PR fixes a bunch of accessible issues ensuring correct tabbing, voice-over. 
Also ensures the correct value is set.