### PR TITLE
refactor(baks-components-vue): change to type from interface

### DIFF
--- a/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
+++ b/packages/vue-components/lib/components/baks-accordion/BaksAccordion.vue
@@ -48,10 +48,10 @@
 import { type ThemeVariant, resolveVariant } from 'baks-components-styles';
 import ChevronDown from '../Icons/ChevronDown.vue';
 import { ref, useId } from 'vue';
-interface Props {
+type Props = {
   variant: ThemeVariant;
   isExpanded?: string;
-}
+};
 
 const props = defineProps<Props>();
 

--- a/packages/vue-components/lib/components/baks-button/BaksButton.vue
+++ b/packages/vue-components/lib/components/baks-button/BaksButton.vue
@@ -12,12 +12,12 @@
 <script setup lang="ts">
 import { type ThemeVariant, resolveVariant } from 'baks-components-styles';
 
-interface Props {
+type Props = {
   type?: 'button' | 'submit' | 'reset';
   variant: ThemeVariant;
   size?: 'normal' | 'block';
   disabled?: boolean;
-}
+};
 
 const props = withDefaults(defineProps<Props>(), {
   type: 'button',

--- a/packages/vue-components/lib/components/baks-card/BaksCard.vue
+++ b/packages/vue-components/lib/components/baks-card/BaksCard.vue
@@ -11,8 +11,8 @@
 <script setup lang="ts">
 import { type ThemeVariant, resolveVariant } from 'baks-components-styles';
 
-interface Props {
+type Props = {
   variant: ThemeVariant;
-}
+};
 const props = defineProps<Props>();
 </script>

--- a/packages/vue-components/lib/components/baks-select/BaksSelect.vue
+++ b/packages/vue-components/lib/components/baks-select/BaksSelect.vue
@@ -78,7 +78,7 @@ interface Option {
   label: string | number;
 }
 
-interface Props {
+type Props = {
   id: string;
   // eslint-disable-next-line vue/prop-name-casing
   'aria-labelledby': string;
@@ -86,7 +86,7 @@ interface Props {
   variant: ThemeVariant;
   options: Option[];
   selectLabel?: string;
-}
+};
 
 const props = withDefaults(defineProps<Props>(), {
   selectLabel: 'Select'

--- a/packages/vue-components/lib/components/baks-tabs/BaksTab.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTab.vue
@@ -1,10 +1,10 @@
 <template>
   <button
+    ref="element"
     type="button"
     class="bk-tab block text-center rounded-sm hover min-w-16 w-28 p-3"
     :class="[resolveVariant(variant), { 'is-selected': isSelected }]"
     part="bk-tab"
-    ref="element"
     :aria-controls="controls"
     :aria-selected="isSelected"
     role="tab"
@@ -18,12 +18,12 @@ import { resolveVariant } from 'baks-components-styles';
 import type { ThemeVariant } from 'baks-components-styles';
 import { ref, watch } from 'vue';
 
-interface Props {
+type Props = {
   variant: ThemeVariant;
   tabGroup: string;
   selected?: boolean;
   controls: string;
-}
+};
 
 const props = withDefaults(defineProps<Props>(), {
   selected: false

--- a/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
+++ b/packages/vue-components/lib/components/baks-tabs/BaksTabPanel.vue
@@ -1,22 +1,21 @@
 <template>
   <div
+    :id="$attrs.id as string"
     part="bk-tab-panel"
     role="tabpanel"
     class="p-4 bk-tab-panel"
     :class="{ hidden: !props.isVisible }"
     :aria-labelledby="controlledBy"
-    :id="($attrs.id as string)"
   >
     <slot></slot>
   </div>
 </template>
 
 <script setup lang="ts">
-
-interface Props {
+type Props = {
   isVisible?: boolean;
   controlledBy: string;
-}
+};
 
 const props = withDefaults(defineProps<Props>(), {
   isVisible: false


### PR DESCRIPTION
Using `type` is much better to use when building library and generating d.ts. Especially when this components need to be exported as web components.