### PR TITLE
feat(baks-components-web): improve typings

### DIFF
--- a/packages/vue-components/README.md
+++ b/packages/vue-components/README.md
@@ -1,5 +1,23 @@
 # Baks Vue components
 
-A collection of vue components.
+A component library build with Vue 3 & Tailwind 4.
 
-The components are built with the mindset of being able to consume them as web components.
+Some of the components are built with the mindset of being able to consume them as web components.
+
+## Installation & Setup
+
+```
+npm install baks-components-vue
+```
+
+Lets import the style, e.g in `app.css`
+
+```css
+@import 'tailwindcss';
+@import 'baks-components-vue/themes/default.css';
+@import 'baks-components-vue/style.css';
+```
+
+### Using custom theme
+Theming is essentially just CSS variables either through tailwind or native.
+For a list of all theme variables using the default theme see [default theme](https://github.com/Tjaitil/baks-components/blob/main/packages/shared/src/css/themes/default.css)

--- a/packages/vue-components/README.md
+++ b/packages/vue-components/README.md
@@ -1,23 +1,5 @@
 # Baks Vue components
 
-A component library build with Vue 3 & Tailwind 4.
+A collection of vue components.
 
-Some of the components are built with the mindset of being able to consume them as web components.
-
-## Installation & Setup
-
-```
-npm install baks-components-vue
-```
-
-Lets import the style, e.g in `app.css`
-
-```css
-@import 'tailwindcss';
-@import 'baks-components-vue/themes/default.css';
-@import 'baks-components-vue/style.css';
-```
-
-### Using custom theme
-Theming is essentially just CSS variables either through tailwind or native.
-For a list of all theme variables using the default theme see [default theme](https://github.com/Tjaitil/baks-components/blob/main/packages/shared/src/css/themes/default.css)
+The components are built with the mindset of being able to consume them as web components.

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,2 +1,45 @@
 # baks-components-web
-A collection of web components.
+A web component library built with vue 3/lit & tailwind 4.
+
+
+## Why both Lit & Vue 3?
+Although vue 3 can be used to build web components it has some shortcomings.
+Especially with form elements that need to use the `attachInternals` api.
+See [issue](https://github.com/vuejs/core/issues/10948#issuecomment-2877323232).
+
+
+## Installation & Setup
+```
+npm install baks-components-web
+```
+
+Lets import the style, e.g in `app.css`
+
+```css
+@import 'tailwindcss';
+@import 'baks-components-vue/themes/default.css';
+@import 'baks-components-vue/style.css';
+```
+
+### Define Web Components
+In order to get anything rendered we need to define the web component as tags.
+```ts
+import { register } from 'baks-components-web';
+register(specificComponents: Components[] = []);
+```
+If not specified, `register` will define all html-tags.
+Use `specificComponents` parameter to have full control over what tags are defined.
+
+### TypeScript Support
+The package provides global typings, therefore you need to opt-in by importing them. This is to prevent unexpected module augmentation.
+*Vue* 
+```ts
+// Augments Vue `GlobalComponents` interface.
+import 'baks-components-web/vue-types';
+```
+
+*JS/TS*
+```ts
+// Augments Global `HTMLElementTagNameMap` interface
+import 'baks-components-web/html-types';
+```

--- a/packages/web-components/lib/DefineCustomElement.ts
+++ b/packages/web-components/lib/DefineCustomElement.ts
@@ -1,0 +1,35 @@
+import { EmitFn, HTMLAttributes, PublicProps } from 'vue';
+
+/**
+ * @see All credits to https://vuejs.org/guide/extras/web-components#non-vue-web-components-and-typescript
+ */
+// We can re-use this type helper per each element we need to define.
+export type DefineCustomElement<
+  ElementType extends HTMLElement,
+  Events extends EventMap = {},
+  SelectedAttributes extends keyof ElementType = keyof ElementType
+> = new () => ElementType & {
+  // Use $props to define the properties exposed to template type checking. Vue
+  // specifically reads prop definitions from the `$props` type. Note that we
+  // combine the element's props with the global HTML props and Vue's special
+  // props.
+  /** @deprecated Do not use the $props property on a Custom Element ref, 
+    this is for template prop types only. */
+  $props: HTMLAttributes & Partial<Pick<ElementType, SelectedAttributes>> & PublicProps;
+
+  // Use $emit to specifically define event types. Vue specifically reads event
+  // types from the `$emit` type. Note that `$emit` expects a particular format
+  // that we map `Events` to.
+  /** @deprecated Do not use the $emit property on a Custom Element ref, 
+    this is for template prop types only. */
+  $emit: VueEmit<Events>;
+};
+
+type EventMap = {
+  [event: string]: Event;
+};
+
+// This maps an EventMap to the format that Vue's $emit type expects.
+type VueEmit<T extends EventMap> = EmitFn<{
+  [K in keyof T]: (event: T[K]) => void;
+}>;

--- a/packages/web-components/lib/components/baks-button/BaksButton.ts
+++ b/packages/web-components/lib/components/baks-button/BaksButton.ts
@@ -1,9 +1,9 @@
 import { html, LitElement, unsafeCSS } from 'lit';
 import style from 'baks-components-styles/src/css/baks-button.css?inline';
 import variant from 'baks-components-styles/src/css/variant.css?inline';
-import { customElement, property } from 'lit/decorators.js';
+import { ThemeVariant } from 'baks-components-styles';
+import { property } from 'lit/decorators.js';
 
-@customElement('baks-button')
 export class BaksButton extends LitElement {
   static styles = unsafeCSS(style + variant);
   static formAssociated = true;
@@ -30,7 +30,7 @@ export class BaksButton extends LitElement {
   }
 
   @property({ type: String })
-  variant = 'primary';
+  variant: ThemeVariant;
 
   get _variantClassName() {
     return `bk-${this.variant}`;

--- a/packages/web-components/lib/components/baks-card/BaksCard.ce.vue
+++ b/packages/web-components/lib/components/baks-card/BaksCard.ce.vue
@@ -11,10 +11,10 @@
 <script setup lang="ts">
 import { type ThemeVariant, resolveVariant } from 'baks-components-styles';
 
-interface Props {
+type Props = {
   variant: ThemeVariant;
-}
-const props = defineProps<Props>();
+};
+defineProps<Props>();
 </script>
 
 <style>

--- a/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
+++ b/packages/web-components/lib/components/baks-tabs/BaksTabsList.ce.vue
@@ -2,19 +2,20 @@
   <div
     class="bk-tabs-list-w"
     ref="tabsWrapper"
-    part="bk-tabs-list-w" :class="direction"
+    part="bk-tabs-list-w"
+    :class="direction"
     role="tablist"
-    >
-      <slot></slot>
+  >
+    <slot></slot>
   </div>
 </template>
 
 <script setup lang="ts">
 import { getCurrentInstance, onMounted, ref, watch } from 'vue';
 
-interface Props {
+type Props = {
   direction?: 'horizontal' | 'vertical';
-}
+};
 
 const props = withDefaults(defineProps<Props>(), {
   direction: 'horizontal'
@@ -60,12 +61,12 @@ onMounted(() => {
       tab.classList.add('special');
       if (tabs.value.length - 1 === index) {
         tab.classList.add('last');
-      } else if(index === 0) {
+      } else if (index === 0) {
         tab.classList.add('first');
       }
     }
 
-    const tabPanelIdentifier = tab.attributes.getNamedItem("controls").value;
+    const tabPanelIdentifier = tab.attributes.getNamedItem('controls').value;
     const element = <HTMLElement>document.querySelectorAll(`#${tabPanelIdentifier}`)[0];
 
     if (element !== undefined) {
@@ -77,12 +78,12 @@ onMounted(() => {
     }
 
     tab.addEventListener('click', (e) => {
-      tabs.value.forEach(element => {
-        if(element !== e.target) {
+      tabs.value.forEach((element) => {
+        if (element !== e.target) {
           element.removeAttribute('selected');
         } else {
           element.setAttribute('selected', '');
-        } 
+        }
       });
       setVisibleTabPanel(tabPanelIdentifier);
     });

--- a/packages/web-components/lib/html-types.d.ts
+++ b/packages/web-components/lib/html-types.d.ts
@@ -1,0 +1,14 @@
+import type { BaksButton } from './components/baks-button/BaksButton';
+
+import type { BaksAccordion, BaksCard, BaksTab, BaksTabList, BaksTabPanel } from '.';
+
+declare global {
+  export interface HTMLElementTagNameMap {
+    'baks-button': BaksButton;
+    'baks-card': InstanceType<typeof BaksCard>;
+    'baks-accordion': InstanceType<typeof BaksAccordion>;
+    'baks-tab': InstanceType<typeof BaksTab>;
+    'baks-tab-panel': InstanceType<typeof BaksTabPanel>;
+    'baks-tab-list': InstanceType<typeof BaksTabList>;
+  }
+}

--- a/packages/web-components/lib/index.ts
+++ b/packages/web-components/lib/index.ts
@@ -1,37 +1,31 @@
 import { defineCustomElement } from 'vue';
-import { BaksButton } from './components/baks-button/BaksButton'
+
 import './app.css';
 import { registerComponent } from './utilities/registerComponent';
 import BaksCardCe from './components/baks-card/BaksCard.ce.vue';
-import BaksAccordion from 'baks-components-vue/lib/components/baks-accordion/BaksAccordion.vue';
-import BaksTab from 'baks-components-vue/lib/components/baks-tabs/BaksTab.vue';
-import BaksTabPanel from 'baks-components-vue/lib/components/baks-tabs/BaksTabPanel.vue';
-import BaksTabList from './components/baks-tabs/BaksTabsList.ce.vue';
+import BaksAccordionCe from 'baks-components-vue/lib/components/baks-accordion/BaksAccordion.vue';
+import BaksTabCe from 'baks-components-vue/lib/components/baks-tabs/BaksTab.vue';
+import BaksTabPanelCe from 'baks-components-vue/lib/components/baks-tabs/BaksTabPanel.vue';
+import BaksTabListCe from './components/baks-tabs/BaksTabsList.ce.vue';
 import css from './app.css?inline';
+import { BaksButton } from './components/baks-button/BaksButton';
 export type { ThemeVariant as ThemeVariants } from 'baks-components-styles';
 
 const BaksCard = defineCustomElement(BaksCardCe, {
-  'styles': [css]
+  styles: [css]
 });
-const BaksAccordionCE = defineCustomElement(BaksAccordion, {
-  'styles': [css
-  ] 
+const BaksAccordion = defineCustomElement(BaksAccordionCe, {
+  styles: [css]
 });
-const BaksTabCE = defineCustomElement(BaksTab, {
-  'styles': [css]
+const BaksTab = defineCustomElement(BaksTabCe, {
+  styles: [css]
 });
-const BaksTabListW = defineCustomElement(BaksTabList);
-const BaksTabPanelCe = defineCustomElement(BaksTabPanel, {
-  'styles': [css]});
+const BaksTabList = defineCustomElement(BaksTabListCe);
+const BaksTabPanel = defineCustomElement(BaksTabPanelCe, {
+  styles: [css]
+});
 
-export {
-  BaksCard,
-  BaksButton,
-  BaksAccordion,
-  BaksTabCE as BaksTab,
-  BaksTabListW as BaksTabList,
-  BaksTabPanelCe as BaksTabPanel
-};
+export { BaksCard, BaksAccordion, BaksTab, BaksTabList, BaksTabPanel };
 
 export type Components =
   | 'BaksButton'
@@ -44,10 +38,11 @@ export type Components =
 export function register(specificComponents: Components[] = []) {
   if (specificComponents.length === 0) {
     registerComponent('baks-card', BaksCard);
-    registerComponent('baks-accordion', BaksAccordionCE);
-    registerComponent('baks-tab', BaksTabCE);
-    registerComponent('baks-tab-panel', BaksTabPanelCe);
-    registerComponent('baks-tab-list', BaksTabListW);
+    registerComponent('baks-accordion', BaksAccordion);
+    registerComponent('baks-tab', BaksTab);
+    registerComponent('baks-tab-panel', BaksTabPanel);
+    registerComponent('baks-tab-list', BaksTabList);
+    registerComponent('baks-button', BaksButton);
   } else {
     specificComponents.forEach((component) => {
       switch (component) {
@@ -55,29 +50,21 @@ export function register(specificComponents: Components[] = []) {
           registerComponent('baks-card', BaksCard);
           break;
         case 'BaksAccordion':
-          registerComponent('baks-accordion', BaksAccordionCE);
+          registerComponent('baks-accordion', BaksAccordion);
           break;
         case 'BaksTab':
-          registerComponent('baks-tab', BaksTabCE);
+          registerComponent('baks-tab', BaksTab);
           break;
         case 'BaksTabPanel':
-          registerComponent('baks-tab-panel', BaksTabPanelCe);
+          registerComponent('baks-tab-panel', BaksTabPanel);
           break;
         case 'BaksTabList':
-          registerComponent('baks-tab-list', BaksTabListW);
+          registerComponent('baks-tab-list', BaksTabList);
+          break;
+        case 'BaksButton':
+          registerComponent('baks-button', BaksButton);
           break;
       }
     });
-  }
-}
-
-declare module 'vue' {
-  export interface GlobalComponents {
-    BaksButton: typeof BaksButton;
-    BaksCard: typeof BaksCard;
-    BaksAccordion: typeof BaksAccordion;
-    BaksTab: typeof BaksTab;
-    BaksTabPanel: typeof BaksTabPanel;
-    BaksTabList: typeof BaksTabListW;
   }
 }

--- a/packages/web-components/lib/utilities/registerComponent.ts
+++ b/packages/web-components/lib/utilities/registerComponent.ts
@@ -1,6 +1,9 @@
 import type { VueElementConstructor } from 'vue';
 
-export const registerComponent = (name: string, component: VueElementConstructor<unknown>) => {
+export const registerComponent = (
+  name: string,
+  component: VueElementConstructor<unknown> | CustomElementConstructor
+) => {
   const element = customElements.get(name);
   if (element === undefined) {
     customElements.define(name, component);

--- a/packages/web-components/lib/vue-types.d.ts
+++ b/packages/web-components/lib/vue-types.d.ts
@@ -1,0 +1,18 @@
+import type { DefineCustomElement } from './DefineCustomElement';
+import type BaksCardCe from './components/baks-card/BaksCard.ce.vue';
+import type BaksAccordionCe from 'baks-components-vue/lib/components/baks-accordion/BaksAccordion.vue';
+import type BaksTabCe from 'baks-components-vue/lib/components/baks-tabs/BaksTab.vue';
+import type BaksTabPanelCe from 'baks-components-vue/lib/components/baks-tabs/BaksTabPanel.vue';
+import type BaksTabListCe from './components/baks-tabs/BaksTabsList.ce.vue';
+import type { BaksButton } from './components/baks-button/BaksButton';
+
+declare module 'vue' {
+  export interface GlobalComponents {
+    'baks-button': DefineCustomElement<BaksButton, {}, 'variant' | 'size' | 'type'>;
+    'baks-card': typeof BaksCardCe;
+    'baks-accordion': typeof BaksAccordionCe;
+    'baks-tab': typeof BaksTabCe;
+    'baks-tab-panel': typeof BaksTabPanelCe;
+    'baks-tab-list': typeof BaksTabListCe;
+  }
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -6,7 +6,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "lib/vue-types.d.ts",
+    "lib/html-types.d.ts"
   ],
   "author": "Kjetil Baksaas",
   "license": "MIT",
@@ -18,12 +20,14 @@
   "exports": {
     "./components/baks-button": "./dist/components/baks-button/BaksButton.js",
     ".": "./dist/index.js",
+    "./vue-types": "./lib/vue-types.d.ts",
+    "./html-types": "./lib/html-types.d.ts",
     "./style.css": "./dist/index.css",
     "./themes/default.css": "./dist/themes/default.css"
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build-only",
+    "build": "npm run build-only && npm run types",
     "preview": "vite preview",
     "build-only": "vite build",
     "types": "vue-tsc -p tsconfig.build.json",

--- a/packages/web-components/tsconfig.build.json
+++ b/packages/web-components/tsconfig.build.json
@@ -1,16 +1,38 @@
 {
-    "compilerOptions": {
-      "target": "ESNext",
-      "moduleResolution": "Node",
-      "outDir": "dist",
-      "declaration": true,
-      "emitDeclarationOnly": true,
-      "downlevelIteration": true,
-      "experimentalDecorators": true,
-      "useDefineForClassFields": false,  
-      "paths": {
-        "@/*": ["./lib/*"]
-      }
-    },
-    "include": ["lib/**/*", "lib/**/*.vue", "lib/**/*.ce.vue", "env.d.ts", "css.d.ts"]
-  }
+  "extends": "@vue/tsconfig/tsconfig.lib.json",
+  "compilerOptions": {
+    "module": "es2022",
+    "target": "es2023",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "downlevelIteration": true,
+    "useDefineForClassFields": false,
+    "allowImportingTsExtensions": true,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "jsx": "preserve",
+    "paths": {
+      "@/*": [
+        "./lib/*"
+      ]
+    }
+  },
+  "include": [
+    "lib/**/*",
+    "lib/**/*.vue",
+    "lib/**/*.ce.vue",
+    "env.d.ts",
+    "css.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "storybook-static",
+    "**/*.stories.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/packages/web-components/vite.config.ts
+++ b/packages/web-components/vite.config.ts
@@ -7,37 +7,37 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://vitejs.dev/config/
 
-export default mergeConfig(rootConfig, defineConfig({
-  define: {
-    'process.env': {}
-  },
-  plugins: [
-    tailwindcss(),
-    vue({
-      customElement: true
-    })
-  ],
-  resolve: {
-    alias: {
-      '@/': fileURLToPath(new URL('./', import.meta.url))
-    }
-  },
-  build: {
-    copyPublicDir: false,
-    lib: {
-      entry: resolve('lib/index.ts'),
-      formats: ['es']
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    plugins: [
+      tailwindcss(),
+      vue({
+        customElement: true
+      })
+    ],
+    resolve: {
+      alias: {
+        '@/': fileURLToPath(new URL('./', import.meta.url))
+      }
     },
-    rollupOptions: {
-      external: ['vue'],
-      output: {
-        globals: {
-          vue: 'Vue'
-        },
-        entryFileNames(chunkInfo) {
-          return `${chunkInfo.name}.js`;
+    build: {
+      copyPublicDir: false,
+      lib: {
+        entry: resolve('lib/index.ts'),
+        formats: ['es']
+      },
+      rollupOptions: {
+        external: ['vue'],
+        output: {
+          globals: {
+            vue: 'Vue'
+          },
+          entryFileNames(chunkInfo) {
+            return `${chunkInfo.name}.js`;
+          }
         }
       }
     }
-  }
-}));
+  })
+);


### PR DESCRIPTION
Improves typings both for use in html and as well as vue.
The previous typings were not working correctly.
Follow the pattern on [vue](https://vuejs.org/guide/extras/web-components.html#non-vue-web-components-and-typescript) to not export the typings directly and cause unexpected augmentation errors.