### PR TITLE
fix(baks-components-web): <style> content not present in custom element

### DIFF
--- a/packages/web-components/lib/index.ts
+++ b/packages/web-components/lib/index.ts
@@ -12,17 +12,17 @@ import { BaksButton } from './components/baks-button/BaksButton';
 export type { ThemeVariant as ThemeVariants } from 'baks-components-styles';
 
 const BaksCard = defineCustomElement(BaksCardCe, {
-  styles: [css]
+  styles: [css, ...(BaksCardCe?.styles ?? [])]
 });
 const BaksAccordion = defineCustomElement(BaksAccordionCe, {
-  styles: [css]
+  styles: [css, ...(BaksAccordionCe?.styles ?? [])]
 });
 const BaksTab = defineCustomElement(BaksTabCe, {
-  styles: [css]
+  styles: [css, ...(BaksTabCe?.styles ?? [])]
 });
 const BaksTabList = defineCustomElement(BaksTabListCe);
 const BaksTabPanel = defineCustomElement(BaksTabPanelCe, {
-  styles: [css]
+  styles: [css, ...(BaksTabPanelCe?.styles ?? [])]
 });
 
 export { BaksCard, BaksAccordion, BaksTab, BaksTabList, BaksTabPanel };


### PR DESCRIPTION
The current implementation overwrites the css extracted from <style> tags. This change ensures that it is present.